### PR TITLE
Add input structure support to relay

### DIFF
--- a/.github/workflows/relay-test.yml
+++ b/.github/workflows/relay-test.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
-    
+
       - name: Install protoc
         run: |
           PROTOC_ZIP=protoc-3.14.0-linux-x86_64
@@ -66,7 +66,7 @@ jobs:
           go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1
           chmod +x $(go env GOPATH)/bin/*
           export PATH="$PATH:$(go env GOPATH)/bin"
-          
+
           make all
 
       - name: docker-compose up
@@ -74,7 +74,7 @@ jobs:
         run: |
           set -x
 
-          docker-compose -f ./yamls/docker-compose/dc-aes-go.yml up &> log_file &
+          docker-compose -f ./yamls/docker-compose/dc-aes-go.yaml up &> log_file &
           sleep 15
 
       - name: Invoke
@@ -90,6 +90,7 @@ jobs:
           echo '[ { "hostname": "localhost" } ]' > endpoints.json
           ./invoker -port 50000 -dbg
           cat rps*lat.csv
-      
+
       - name: Show docker-compose log
-        run: cat benchmarks/chained-function-serving/log_file
+        working-directory: benchmarks/aes
+        run: cat log_file

--- a/.github/workflows/relay-test.yml
+++ b/.github/workflows/relay-test.yml
@@ -1,0 +1,95 @@
+# MIT License
+#
+# Copyright (c) 2022 EASE lab
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+name: Relay Tests
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  GOOS: linux
+  GO111MODULE: on
+
+jobs:
+  integration-tests:
+    name: Relay Integration Tests
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+    
+      - name: Install protoc
+        run: |
+          PROTOC_ZIP=protoc-3.14.0-linux-x86_64
+          curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/$PROTOC_ZIP.zip
+          unzip -o $PROTOC_ZIP.zip -d $HOME/.local
+          chmod +x $HOME/.local/bin/protoc
+          rm -f $PROTOC_ZIP.zip
+
+      - name: Build relay
+        working-directory: tools/relay
+        run: |
+          set -x
+          go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.26
+          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1
+          chmod +x $(go env GOPATH)/bin/*
+          export PATH="$PATH:$(go env GOPATH)/bin"
+          
+          make all
+
+      - name: docker-compose up
+        working-directory: benchmarks/aes
+        run: |
+          set -x
+
+          docker-compose -f ./yamls/docker-compose/dc-aes-go.yml up &> log_file &
+          sleep 15
+
+      - name: Invoke
+        working-directory: tools/invoker
+        run: |
+          set -x
+          go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.26
+          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1
+          chmod +x $(go env GOPATH)/bin/*
+          export PATH="$PATH:$(go env GOPATH)/bin"
+
+          make invoker
+          echo '[ { "hostname": "localhost" } ]' > endpoints.json
+          ./invoker -port 50000 -dbg
+          cat rps*lat.csv
+      
+      - name: Show docker-compose log
+        run: cat benchmarks/chained-function-serving/log_file

--- a/tools/relay/README.md
+++ b/tools/relay/README.md
@@ -19,7 +19,7 @@ relay:
     - published: 50000
       target: 50000
 ```
-where FUNCTION_NAME is replaced by the name you have added to the `getclient.go` in the [vSwarm-proto repository](https://github.com/ease-lab/vSwarm-proto/blob/main/grpcclient/getclient.go). You can remove the published port of your benchmark server now (which is now FUNCTION_PORT). 
+where FUNCTION_NAME is replaced by the name you have added to the `getclient.go` in the [vSwarm-proto repository](https://github.com/ease-lab/vSwarm-proto/blob/main/grpcclient/getclient.go). You can remove the published port of your benchmark server now (the `CONTAINER_PORT` is now FUNCTION_PORT, see [docker networking](https://docs.docker.com/compose/networking/)).
 
 To understand the URL setting in detail check [here in docker docs](https://docs.docker.com/compose/networking/) to find out how docker network works.  
 Generally speaking in this case docker compose sets up a single network between the relay and the function container. Now the function container is reachable from the relay via the service/container name. See [docker networking](https://docs.docker.com/compose/networking/) or aes-go as an example

--- a/tools/relay/README.md
+++ b/tools/relay/README.md
@@ -48,3 +48,14 @@ Simply use invoker on port 50000.
 echo '[ { "hostname": "0.0.0.0" } ]' > endpoints.json
 ./invoker -port 50000
 ```
+
+## Debugging
+
+You simply need to set the `ENABLE_DEBUGGING` shell environment variable to `true` to enable debug logging.
+
+In docker-compose file you can add
+
+```yaml
+    environment:
+      - ENABLE_DEBUGGING=true
+```

--- a/tools/relay/go.mod
+++ b/tools/relay/go.mod
@@ -5,7 +5,7 @@ go 1.16
 replace github.com/ease-lab/vSwarm/utils/tracing/go => ../../utils/tracing/go
 
 require (
-	github.com/ease-lab/vSwarm-proto v0.0.0-20220425132824-72aa8060e781
+	github.com/ease-lab/vSwarm-proto v0.0.0-20220427122029-56a3f1323dde
 	github.com/ease-lab/vSwarm/utils/tracing/go v0.0.0-20220421212014-f17df208fc40
 	github.com/sirupsen/logrus v1.8.1
 	google.golang.org/grpc v1.46.0

--- a/tools/relay/go.mod
+++ b/tools/relay/go.mod
@@ -5,8 +5,8 @@ go 1.16
 replace github.com/ease-lab/vSwarm/utils/tracing/go => ../../utils/tracing/go
 
 require (
-	github.com/ease-lab/vSwarm-proto v0.0.0-20220427122029-56a3f1323dde
-	github.com/ease-lab/vSwarm/utils/tracing/go v0.0.0-20220421212014-f17df208fc40
+	github.com/ease-lab/vSwarm-proto v0.0.0-20220428102506-7b5de12d00b8
+	github.com/ease-lab/vSwarm/utils/tracing/go v0.0.0-20220427112636-f8f3fc171804
 	github.com/sirupsen/logrus v1.8.1
 	google.golang.org/grpc v1.46.0
 )

--- a/tools/relay/go.mod
+++ b/tools/relay/go.mod
@@ -5,7 +5,7 @@ go 1.16
 replace github.com/ease-lab/vSwarm/utils/tracing/go => ../../utils/tracing/go
 
 require (
-	github.com/ease-lab/vSwarm-proto v0.0.0-20220428102506-7b5de12d00b8
+	github.com/ease-lab/vSwarm-proto v0.1.2
 	github.com/ease-lab/vSwarm/utils/tracing/go v0.0.0-20220427112636-f8f3fc171804
 	github.com/sirupsen/logrus v1.8.1
 	google.golang.org/grpc v1.46.0

--- a/tools/relay/go.sum
+++ b/tools/relay/go.sum
@@ -313,6 +313,8 @@ github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/ease-lab/vSwarm-proto v0.0.0-20220425132824-72aa8060e781 h1:fvwfnS84LJplOTEO73mRpvayPkb0aQQBpR5EG88C2Ag=
 github.com/ease-lab/vSwarm-proto v0.0.0-20220425132824-72aa8060e781/go.mod h1:CZMjQ4jrHBB+PhKbgAsL9WGEja1PN/HqizfI1Hg3wmw=
+github.com/ease-lab/vSwarm-proto v0.0.0-20220427122029-56a3f1323dde h1:h7pkmnvXvYMG6obzUsjr1fsh7hUuP0zYY9YWyOr9zCU=
+github.com/ease-lab/vSwarm-proto v0.0.0-20220427122029-56a3f1323dde/go.mod h1:CZMjQ4jrHBB+PhKbgAsL9WGEja1PN/HqizfI1Hg3wmw=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=

--- a/tools/relay/go.sum
+++ b/tools/relay/go.sum
@@ -311,8 +311,8 @@ github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25Kn
 github.com/eapache/go-resiliency v1.2.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
-github.com/ease-lab/vSwarm-proto v0.0.0-20220428102506-7b5de12d00b8 h1:0aJ6r9SSoq8R3shh4G7Z1k6jQMvvX86yeFmBJr5D0jY=
-github.com/ease-lab/vSwarm-proto v0.0.0-20220428102506-7b5de12d00b8/go.mod h1:zc7JibDJiX/H7plx3xq5OAC/qp1yiL+O6dZH9GnSzao=
+github.com/ease-lab/vSwarm-proto v0.1.2 h1:kguVPuKo6vJUH/83cln41WiAI1KsWiX9WKplNjJoDS8=
+github.com/ease-lab/vSwarm-proto v0.1.2/go.mod h1:zc7JibDJiX/H7plx3xq5OAC/qp1yiL+O6dZH9GnSzao=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=

--- a/tools/relay/go.sum
+++ b/tools/relay/go.sum
@@ -311,10 +311,8 @@ github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25Kn
 github.com/eapache/go-resiliency v1.2.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
-github.com/ease-lab/vSwarm-proto v0.0.0-20220425132824-72aa8060e781 h1:fvwfnS84LJplOTEO73mRpvayPkb0aQQBpR5EG88C2Ag=
-github.com/ease-lab/vSwarm-proto v0.0.0-20220425132824-72aa8060e781/go.mod h1:CZMjQ4jrHBB+PhKbgAsL9WGEja1PN/HqizfI1Hg3wmw=
-github.com/ease-lab/vSwarm-proto v0.0.0-20220427122029-56a3f1323dde h1:h7pkmnvXvYMG6obzUsjr1fsh7hUuP0zYY9YWyOr9zCU=
-github.com/ease-lab/vSwarm-proto v0.0.0-20220427122029-56a3f1323dde/go.mod h1:CZMjQ4jrHBB+PhKbgAsL9WGEja1PN/HqizfI1Hg3wmw=
+github.com/ease-lab/vSwarm-proto v0.0.0-20220428102506-7b5de12d00b8 h1:0aJ6r9SSoq8R3shh4G7Z1k6jQMvvX86yeFmBJr5D0jY=
+github.com/ease-lab/vSwarm-proto v0.0.0-20220428102506-7b5de12d00b8/go.mod h1:zc7JibDJiX/H7plx3xq5OAC/qp1yiL+O6dZH9GnSzao=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=

--- a/tools/relay/server.go
+++ b/tools/relay/server.go
@@ -58,6 +58,7 @@ var lowerBound = flag.Int("lowerBound", 1, "Lower bound while generating input")
 var upperBound = flag.Int("upperBound", 10, "Upper bound while generating input")
 var generatorString = flag.String("generator", "unique", "Generator type (unique / linear / random)")
 var value = flag.String("value", "helloWorld", "String input to pass to benchmark")
+var functionMethod = flag.String("function-method", "default", "Which method of benchmark to invoke")
 
 func isDebuggingEnabled() bool {
 	if val, ok := os.LookupEnv("ENABLE_DEBUGGING"); !ok || val == "false" {
@@ -141,6 +142,7 @@ func SendMessageToBenchmark(in *pb.HelloRequest) string {
 	pkt.SetValue(*value)
 	pkt.SetLowerBound(*lowerBound)
 	pkt.SetUpperBound(*upperBound)
+	pkt.SetMethod(*functionMethod)
 	reply := grpcClient.Request(pkt)
 	log.Debug(reply)
 	return reply


### PR DESCRIPTION
- Adds support for specifying [`Input`](https://github.com/ease-lab/vSwarm-proto/blob/main/grpcclient/grpcclient.go#L26) parameters from relay shell arguments
- Updates relay README to specify debugging procedure
- Adds relay CI test