### PR TITLE
linkchecker: Added a workaround for links pointing to github repos

### DIFF
--- a/.github/configs/linkcheck.json
+++ b/.github/configs/linkcheck.json
@@ -12,5 +12,13 @@
             "pattern": "^/",
             "replacement": "/github/workspace/"
         }
+    ],
+    "httpHeaders": [
+        {
+            "urls": ["https://docs.github.com/"],
+            "headers": {
+                "Accept-Encoding": "zstd, br, gzip, deflate"
+            }
+        }
     ]
 }


### PR DESCRIPTION
Signed-off-by: Dmitrii Ustiugov <dmitrii.ustiugov@ed.ac.uk>