### PR TITLE
Change logic of getting http status code for `trace-plotter` tool

### DIFF
--- a/tools/trace-plotter/plot.go
+++ b/tools/trace-plotter/plot.go
@@ -25,7 +25,6 @@ package main
 import (
 	"fmt"
 	"sort"
-	"strconv"
 
 	log "github.com/sirupsen/logrus"
 
@@ -119,7 +118,7 @@ func PlotGraph(traces []*Trace, durations []float64, zipkinURL string, latencyTy
 	successItems := make([]opts.ScatterData, 0)
 	errorItems := make([]opts.ScatterData, 0)
 	for i, trace := range traces {
-		resp, err := strconv.Atoi(trace.Tags.HTTPStatusCode)
+		resp, err := trace.GetHTTPStatusCode()
 		if err != nil || resp > 300 {
 			errorItems = append(errorItems, opts.ScatterData{
 				Name:         trace.TraceID,


### PR DESCRIPTION
Signed-off-by: Dohyun Park <dohyun1357@gmail.com>

Add `GetHTTPStatusCode` function that looks through the trace tree and gets the top-level HTTP status code.
If the HTTP status code is missing from the parent trace, it traverses its child nodes until it finds an HTTP status code.